### PR TITLE
merge unstable to main

### DIFF
--- a/kc/boot/kc_main.c
+++ b/kc/boot/kc_main.c
@@ -219,7 +219,7 @@ static void collect_video_data(void)
 
         boot_data.video = (struct kc_boot_video_data){
             {
-                RESERVED_MEMORY,
+                MMIO_MEMORY,
                     mode->FrameBufferBase,
                     mode->FrameBufferSize
             },

--- a/kc/core/memory/page_early.c
+++ b/kc/core/memory/page_early.c
@@ -19,6 +19,17 @@ void page_early_init(void)
     early_state.first = &boot_data->memory.entries[0];
     early_state.last = &boot_data->memory.entries[boot_data->memory.count];
     early_state.current = early_state.first;
+
+    kprintf("memory ranges\n");
+
+    struct memory_range *current = early_state.first;
+
+    do
+    {
+        kprintf("base %#0.16lx size %#0.16lx type %d\n", current->base, current->size, current->type);
+        current++;
+    }
+    while (current != early_state.last);
 }
 
 void page_early_final(void)
@@ -30,7 +41,7 @@ void page_early_final(void)
                 current < early_state.last;
                 current++)
         {
-            while (current->size >= page_size(1))
+            while (current->type != RESERVED_MEMORY && current->size >= page_size(1))
             {
                 current->size -= page_size(1);
 
@@ -44,7 +55,6 @@ void page_early_final(void)
 
                 switch (type)
                 {
-                    case RESERVED_MEMORY:
                     case SYSTEM_MEMORY:
                         page_set_present(page);
                         break;

--- a/kc/core/pic8259.c
+++ b/kc/core/pic8259.c
@@ -43,6 +43,7 @@ static void wait(void)
 
 void pic8259_init(void)
 {
+    kprintf("initializing legacy pic\n");
     // basic init. not gonna fret with this too much
     outb(PIC_PRI_CMD, ICW1_INIT|ICW1_ICW4);
     wait();


### PR DESCRIPTION
issues with qemu that could cause excessive memory regions created at boot time. ignore memory regions that aren't backed by physical addresses